### PR TITLE
Fix Build system for windows native build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libhangul"]
+	path = libhangul
+	url = https://github.com/libhangul/libhangul.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,12 @@ set(hangul_USE_STATIC_LIBS OFF)
 set(GObject_USE_STATIC_LIBS OFF)
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(hangul libhangul REQUIRED)
 pkg_check_modules(GObject REQUIRED gobject-2.0)
-add_library(hanjp hanjpautomata.c hanjpinputcontext.c hanjpkeyboard.c)
-target_include_directories(hanjp PUBLIC ${hangul_INCLUDE_DIRS} ${GObject_INCLUDE_DIRS})
-target_link_libraries(hanjp ${hangul_LIBRARIES} ${GObject_LIBRARIES})
+add_library(hanjp hanjpautomata.c hanjpinputcontext.c hanjpkeyboard.c 
+    ${PROJECT_SOURCE_DIR}/libhangul/hangul/hangulctype.c 
+    ${PROJECT_SOURCE_DIR}/libhangul/hangul/hangulkeyboard.c
+)
+target_include_directories(hanjp PUBLIC ${GObject_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/libhangul/hangul)
+target_link_libraries(hanjp ${GObject_LIBRARIES})
 
 add_subdirectory(test EXCLUDE_FROM_ALL)

--- a/README.md
+++ b/README.md
@@ -5,11 +5,10 @@ You can use GObject Introspection for cross-language interoperability.
 
 ## How can we build?
 ```
-git clone https://github.com/Hanjp-IM/libhanjp.git
+git clone --recurse-submodules https://github.com/Hanjp-IM/libhanjp.git
 cd libhanjp
 mkdir build
 cd build
-git submodule add
 cmake ..
 make
 ```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ git clone https://github.com/Hanjp-IM/libhanjp.git
 cd libhanjp
 mkdir build
 cd build
+git submodule add
 cmake ..
 make
 ```

--- a/hanjpkeyboard.c
+++ b/hanjpkeyboard.c
@@ -1,5 +1,5 @@
 #include "hanjpkeyboard.h"
-#include <hangul.h>
+#include "hangul.h"
 
 G_DEFINE_INTERFACE(HanjpKeyboard, hanjp_keyboard, G_TYPE_OBJECT)
 


### PR DESCRIPTION
기존에는 linux native에서만 빌드가 가능했지만 windows native에서도 빌드가 가능하게 하기위해 수정함
libhangul이 MinGW에서 사용할 수 있도록 패키징 되어있지 않아서 빌드할 수 있도록 CMake를 다운로드하고 아래의 파일을 수정함

-.gitmodules에 libhangul을 libhanjp의 submodule을 추가함
-CMakeLists.txt에 시스템에서 패키지를 읽던 것에서 서브모듈 소스코드에서 직접 읽도록 바꿈
-hanjpkeyboard.c에 hangul.h를 삭제하고 libhangul을 사용하기위한 선언부를 추가함
 