### PR TITLE
Implement ic_ref_string

### DIFF
--- a/hanjpinputcontext.c
+++ b/hanjpinputcontext.c
@@ -135,23 +135,32 @@ gboolean hanjp_ic_backspace(HanjpInputContext *self)
 
 GArray* hanjp_ic_ref_preedit_string(HanjpInputContext *self)
 {
+    HanjpInputContextPrivate *priv;
+
     g_return_if_fail(HANJP_IS_INPUTCONTEXT(self));
 
-    // to implement
+    priv = hanjp_ic_get_instance_private(self);
+    return g_array_ref(priv->preedit);
 }
 
 GArray* hanjp_ic_ref_commit_string(HanjpInputContext *self)
 {
+    HanjpInputContextPrivate *priv;
+
     g_return_if_fail(HANJP_IS_INPUTCONTEXT(self));
 
-    // to implement
+    priv = hanjp_ic_get_instance_private(self);
+    return g_array_ref(priv->committed);
 }
 
 GArray* hanjp_ic_ref_hangul_string(HanjpInputContext *self)
 {
+    HanjpInputContextPrivate *priv;
+
     g_return_if_fail(HANJP_IS_INPUTCONTEXT(self));
 
-    // to implement
+    priv = hanjp_ic_get_instance_private(self);
+    return g_array_ref(priv->hangul);
 }
 
 void hanjp_ic_set_am(HanjpInputContext *self, gint i)


### PR DESCRIPTION
* `hanjp_ic_ref_preedit_string`, `hanjp_ic_ref_commit_string`, `hanjp_ic_ref_hangul_string` 함수 구현
* 해당 함수를 통해 참조한 객체는 사용 후 `g_array_unref()`함수를 통해 reference count를 감소시켜야 합니다.