### PR TITLE
implement get_mapping

### DIFF
--- a/hanjpkeyboard.c
+++ b/hanjpkeyboard.c
@@ -5,7 +5,7 @@ G_DEFINE_INTERFACE(HanjpKeyboard, hanjp_keyboard, G_TYPE_OBJECT)
 
 static void
 hanjp_keyboard_default_init(HanjpKeyboardInterface *iface) {
-	iface->get_mapping = hanjp_keyboard_get_mapping;
+	// Nothing to do
 }
 
 gunichar hanjp_keyboard_get_mapping(HanjpKeyboard* self, gint tableid, gint ascii)

--- a/hanjpkeyboard.c
+++ b/hanjpkeyboard.c
@@ -5,7 +5,7 @@ G_DEFINE_INTERFACE(HanjpKeyboard, hanjp_keyboard, G_TYPE_OBJECT)
 
 static void
 hanjp_keyboard_default_init(HanjpKeyboardInterface *iface) {
-    /* add properties and signals to the interface here */
+	iface->get_mapping = hanjp_keyboard_get_mapping;
 }
 
 gunichar hanjp_keyboard_get_mapping(HanjpKeyboard* self, gint tableid, gint ascii)
@@ -34,8 +34,9 @@ hanjp_keyboarddefault_get_mapping(HanjpKeyboard *self, gint tableid, gint ascii)
 {
     HanjpKeyboardDefaultPrivate *priv;
     priv = hanjp_keyboarddefault_get_instance_private(HANJP_KEYBOARDDEFAULT(self));
+	g_return_if_fail(priv->keyboard != NULL);
 
-    // to implement
+	return hangul_keyboard_get_mapping(priv->keyboard, tableid, ascii);
 }
 
 static void 


### PR DESCRIPTION
Implemented two methods:
- `hanjp_keyboard_default_init(HanjpKeyboardInterface *iface)`
-  `gunichar hanjp_keyboard_get_mapping(HanjpKeyboard* self, gint tableid, gint ascii)` 
   +  calls `	hangul_keyboard_get_mapping` and returns the mapped character.

