### PR TITLE
[WIP] Change build directive for better abstraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,10 @@ include(GenerateExportHeader)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GObject REQUIRED gobject-2.0)
-add_library(hanjp hanjpautomata.c hanjpinputcontext.c hanjpkeyboard.c 
-    ${PROJECT_SOURCE_DIR}/libhangul/hangul/hangulctype.c 
-    ${PROJECT_SOURCE_DIR}/libhangul/hangul/hangulkeyboard.c
-)
+add_subdirectory(libhangul)
+add_library(hanjp hanjpautomata.c hanjpinputcontext.c hanjpkeyboard.c)
 target_include_directories(hanjp PUBLIC ${GObject_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/libhangul/hangul)
-target_link_libraries(hanjp ${GObject_LIBRARIES})
+target_link_libraries(hanjp ${GObject_LIBRARIES} hangul)
 generate_export_header(hanjp)
 
 add_subdirectory(test)


### PR DESCRIPTION
Instead read libhangul source code directly, I changed to build and link the library.
It would improve system introspection, provide better flexibility in addition to readability.
Currently, libhangul cannot be built with cmake becuase some file is missing, but it's going to resolved soon.
And I'm waiting for that patch.