### PR TITLE
Refactoring

### DIFF
--- a/hanjpautomata.h
+++ b/hanjpautomata.h
@@ -16,8 +16,8 @@ typedef union {
     gunichar stack[4];
 } HanjpBuffer;
 
-#define HANJP_TYPE_AUTOMATA hanjp_am_get_type()
-G_DECLARE_INTERFACE(HanjpAutomata, hanjp_am, HANJP, AUTOMATA, GObject)
+#define HANJP_TYPE_AM hanjp_am_get_type()
+G_DECLARE_INTERFACE(HanjpAutomata, hanjp_am, HANJP, AM, GObject)
 
 struct _HanjpAutomataInterface
 {
@@ -34,8 +34,8 @@ gint hanjp_am_push(HanjpAutomata *am, GArray *preedit, GArray *hangul, gunichar 
 gboolean hanjp_am_backspace(HanjpAutomata *am);
 void hanjp_am_flush(HanjpAutomata *am);
 
-#define HANJP_TYPE_AUTOMATABASE hanjp_ambase_get_type()
-G_DECLARE_DERIVABLE_TYPE(HanjpAutomataBase, hanjp_ambase, HANJP, AUTOMATABASE, GObject)
+#define HANJP_TYPE_AM_BASE hanjp_am_base_get_type()
+G_DECLARE_DERIVABLE_TYPE(HanjpAutomataBase, hanjp_am_base, HANJP, AM_BASE, GObject)
 
 struct _HanjpAutomataBaseClass
 {
@@ -47,15 +47,15 @@ struct _HanjpAutomataBaseClass
     void (*flush) (HanjpAutomata *self);
 };
 
-#define HANJP_TYPE_AUTOMATADEFAULT hanjp_amdefault_get_type()
-G_DECLARE_DERIVABLE_TYPE(HanjpAutomataDefault, hanjp_amdefault, HANJP, AUTOMATADEFAULT, HanjpAutomataBase)
+#define HANJP_TYPE_AM_BUILTIN hanjp_am_builtin_get_type()
+G_DECLARE_DERIVABLE_TYPE(HanjpAutomataBuiltin, hanjp_am_builtin, HANJP, AM_BUILTIN, HanjpAutomataBase)
 
-struct _HanjpAutomataDefaultClass
+struct _HanjpAutomataBuiltinClass
 {
     HanjpAutomataBaseClass parent_class;
 };
 
-HanjpAutomataDefault *hanjp_amdefault_new();
+HanjpAutomataBuiltin *hanjp_am_builtin_new();
 
 G_END_DECLS
 

--- a/hanjpinputcontext.c
+++ b/hanjpinputcontext.c
@@ -68,7 +68,7 @@ hanjp_ic_init(HanjpInputContext *self)
     HanjpInputContextPrivate *priv;
     priv = hanjp_ic_get_instance_private(self);
 
-    priv->ams[0] = HANJP_AUTOMATA(hanjp_amdefault_new());
+    priv->ams[0] = HANJP_AM(hanjp_am_builtin_new());
     priv->ams[1] = NULL;
     priv->cur_am = g_object_ref(priv->ams[0]);
     priv->keyboard = HANJP_KB(hanjp_kb_builtin_new());

--- a/hanjpinputcontext.c
+++ b/hanjpinputcontext.c
@@ -71,7 +71,7 @@ hanjp_ic_init(HanjpInputContext *self)
     priv->ams[0] = HANJP_AUTOMATA(hanjp_amdefault_new());
     priv->ams[1] = NULL;
     priv->cur_am = g_object_ref(priv->ams[0]);
-    priv->keyboard = HANJP_KEYBOARD(hanjp_keyboarddefault_new());
+    priv->keyboard = HANJP_KB(hanjp_kb_builtin_new());
     priv->preedit = g_array_sized_new(TRUE, TRUE, sizeof(gunichar), 64);
     priv->committed = g_array_sized_new(TRUE, TRUE, sizeof(gunichar), 64);
     priv->hangul = g_array_sized_new(TRUE, TRUE, sizeof(gunichar), 64);
@@ -126,7 +126,7 @@ gint hanjp_ic_process(HanjpInputContext *self, gint ascii)
     priv = hanjp_ic_get_instance_private(self);
 
     //map jaso from ascii
-    ch = hanjp_keyboard_get_mapping(priv->keyboard, 0, ascii);
+    ch = hanjp_kb_get_mapping(priv->keyboard, 0, ascii);
     if(ch == 0) {
         ch = (gunichar)ascii;
     }

--- a/hanjpkeyboard.c
+++ b/hanjpkeyboard.c
@@ -4,84 +4,84 @@
 extern ucschar
 hangul_keyboard_get_mapping(const HangulKeyboard* keyboard, int tableid, unsigned key);
 
-G_DEFINE_INTERFACE(HanjpKeyboard, hanjp_keyboard, G_TYPE_OBJECT)
+G_DEFINE_INTERFACE(HanjpKeyboard, hanjp_kb, G_TYPE_OBJECT)
 
 static void
-hanjp_keyboard_default_init(HanjpKeyboardInterface *iface) {
+hanjp_kb_default_init(HanjpKeyboardInterface *iface) {
 	// Nothing to do
 }
 
-gunichar hanjp_keyboard_get_mapping(HanjpKeyboard* self, gint tableid, gint ascii)
+gunichar hanjp_kb_get_mapping(HanjpKeyboard* self, gint tableid, gint ascii)
 {
     HanjpKeyboardInterface *iface;
 
     g_return_if_fail(HANJP_IS_KEYBOARD(self));
 
-    iface = HANJP_KEYBOARD_GET_IFACE(self);
+    iface = HANJP_KB_GET_IFACE(self);
     g_return_if_fail(iface->get_mapping != NULL);
     return iface->get_mapping(self, tableid, ascii);
 }
 
 typedef struct {
     HangulKeyboard *keyboard;
-} HanjpKeyboardDefaultPrivate;
+} HanjpKeyboardBuiltinPrivate;
 
-static void hanjp_keyboarddefault_keyboard_interface_init(HanjpKeyboardInterface *iface);
-G_DEFINE_TYPE_WITH_CODE(HanjpKeyboardDefault, hanjp_keyboarddefault, G_TYPE_OBJECT,
-        G_ADD_PRIVATE(HanjpKeyboardDefault)
+static void hanjp_kb_builtin_keyboard_interface_init(HanjpKeyboardInterface *iface);
+G_DEFINE_TYPE_WITH_CODE(HanjpKeyboardBuiltin, hanjp_kb_builtin, G_TYPE_OBJECT,
+        G_ADD_PRIVATE(HanjpKeyboardBuiltin)
         G_IMPLEMENT_INTERFACE(HANJP_TYPE_KEYBOARD,
-            hanjp_keyboarddefault_keyboard_interface_init))
+            hanjp_kb_builtin_keyboard_interface_init))
 
-HanjpKeyboardDefault *hanjp_keyboarddefault_new()
+HanjpKeyboardBuiltin *hanjp_kb_builtin_new()
 {
     return g_object_new(HANJP_TYPE_KEYBOARDDEFAULT, NULL);
 }
 
 static gunichar
-hanjp_keyboarddefault_get_mapping(HanjpKeyboard *self, gint tableid, gint ascii)
+hanjp_kb_builtin_get_mapping(HanjpKeyboard *self, gint tableid, gint ascii)
 {
-    HanjpKeyboardDefaultPrivate *priv;
-    priv = hanjp_keyboarddefault_get_instance_private(HANJP_KEYBOARDDEFAULT(self));
+    HanjpKeyboardBuiltinPrivate *priv;
+    priv = hanjp_kb_builtin_get_instance_private(HANJP_KB_BUILTIN(self));
 	g_return_if_fail(priv->keyboard != NULL);
 
 	return hangul_keyboard_get_mapping(priv->keyboard, tableid, ascii);
 }
 
 static void 
-hanjp_keyboarddefault_init(HanjpKeyboardDefault *self)
+hanjp_kb_builtin_init(HanjpKeyboardBuiltin *self)
 {
-    HanjpKeyboardDefaultPrivate *priv;
-    priv = hanjp_keyboarddefault_get_instance_private(self);
+    HanjpKeyboardBuiltinPrivate *priv;
+    priv = hanjp_kb_builtin_get_instance_private(self);
 
     priv->keyboard = hangul_keyboard_list_get_keyboard("2");
 }
 
 static void
-hanjp_keyboarddefault_dispose(GObject *gobject)
+hanjp_kb_builtin_dispose(GObject *gobject)
 {
-    G_OBJECT_CLASS(hanjp_keyboarddefault_parent_class)->dispose(gobject);
+    G_OBJECT_CLASS(hanjp_kb_builtin_parent_class)->dispose(gobject);
 }
 
 static void
-hanjp_keyboarddefault_finalize(GObject *gobject)
+hanjp_kb_builtin_finalize(GObject *gobject)
 {
-    HanjpKeyboardDefaultPrivate *priv;
-    priv = hanjp_keyboarddefault_get_instance_private(HANJP_KEYBOARDDEFAULT(gobject));
+    HanjpKeyboardBuiltinPrivate *priv;
+    priv = hanjp_kb_builtin_get_instance_private(HANJP_KB_BUILTIN(gobject));
     hangul_keyboard_delete(priv->keyboard);
-    G_OBJECT_CLASS(hanjp_keyboarddefault_parent_class)->finalize(gobject);
+    G_OBJECT_CLASS(hanjp_kb_builtin_parent_class)->finalize(gobject);
 }
 
 static void
-hanjp_keyboarddefault_class_init(HanjpKeyboardDefaultClass *klass)
+hanjp_kbdefault_class_init(HanjpKeyboardBuiltinClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
-    object_class->dispose = hanjp_keyboarddefault_dispose;
-    object_class->finalize = hanjp_keyboarddefault_finalize;
+    object_class->dispose = hanjp_kb_builtin_dispose;
+    object_class->finalize = hanjp_kb_builtin_finalize;
 }
 
 static void
-hanjp_keyboarddefault_keyboard_interface_init(HanjpKeyboardInterface *iface)
+hanjp_kb_builtin_keyboard_interface_init(HanjpKeyboardInterface *iface)
 {
-    iface->get_mapping = hanjp_keyboarddefault_get_mapping;
+    iface->get_mapping = hanjp_kb_builtin_get_mapping;
 }

--- a/hanjpkeyboard.c
+++ b/hanjpkeyboard.c
@@ -15,7 +15,7 @@ gunichar hanjp_kb_get_mapping(HanjpKeyboard* self, gint tableid, gint ascii)
 {
     HanjpKeyboardInterface *iface;
 
-    g_return_if_fail(HANJP_IS_KEYBOARD(self));
+    g_return_if_fail(HANJP_IS_KB(self));
 
     iface = HANJP_KB_GET_IFACE(self);
     g_return_if_fail(iface->get_mapping != NULL);
@@ -26,11 +26,11 @@ typedef struct {
     HangulKeyboard *keyboard;
 } HanjpKeyboardBuiltinPrivate;
 
-static void hanjp_kb_builtin_keyboard_interface_init(HanjpKeyboardInterface *iface);
+static void hanjp_kb_builtin_interface_init(HanjpKeyboardInterface *iface);
 G_DEFINE_TYPE_WITH_CODE(HanjpKeyboardBuiltin, hanjp_kb_builtin, G_TYPE_OBJECT,
         G_ADD_PRIVATE(HanjpKeyboardBuiltin)
-        G_IMPLEMENT_INTERFACE(HANJP_TYPE_KEYBOARD,
-            hanjp_kb_builtin_keyboard_interface_init))
+        G_IMPLEMENT_INTERFACE(HANJP_TYPE_KB,
+            hanjp_kb_builtin_interface_init))
 
 HanjpKeyboardBuiltin *hanjp_kb_builtin_new()
 {
@@ -72,7 +72,7 @@ hanjp_kb_builtin_finalize(GObject *gobject)
 }
 
 static void
-hanjp_kbdefault_class_init(HanjpKeyboardBuiltinClass *klass)
+hanjp_kb_builtin_class_init(HanjpKeyboardBuiltinClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
@@ -81,7 +81,7 @@ hanjp_kbdefault_class_init(HanjpKeyboardBuiltinClass *klass)
 }
 
 static void
-hanjp_kb_builtin_keyboard_interface_init(HanjpKeyboardInterface *iface)
+hanjp_kb_builtin_interface_init(HanjpKeyboardInterface *iface)
 {
     iface->get_mapping = hanjp_kb_builtin_get_mapping;
 }

--- a/hanjpkeyboard.h
+++ b/hanjpkeyboard.h
@@ -5,7 +5,7 @@
 
 G_BEGIN_DECLS
 
-#define HANJP_TYPE_KEYBOARD hanjp_keyboard_get_type()
+#define HANJP_TYPE_KB hanjp_kb_get_type()
 G_DECLARE_INTERFACE(HanjpKeyboard, hanjp_kb, HANJP, KB, GObject)
 
 struct _HanjpKeyboardInterface {
@@ -16,7 +16,7 @@ struct _HanjpKeyboardInterface {
 
 gunichar hanjp_kb_get_mapping(HanjpKeyboard *self, gint tableid, gint ascii);
 
-#define HANJP_TYPE_KEYBOARDDEFAULT hanjp_keyboarddefault_get_type()
+#define HANJP_TYPE_KEYBOARDDEFAULT hanjp_kb_builtin_get_type()
 G_DECLARE_DERIVABLE_TYPE(HanjpKeyboardBuiltin, hanjp_kb_builtin, HANJP, KB_BUILTIN, GObject)
 
 struct _HanjpKeyboardBuiltinClass {

--- a/hanjpkeyboard.h
+++ b/hanjpkeyboard.h
@@ -6,7 +6,7 @@
 G_BEGIN_DECLS
 
 #define HANJP_TYPE_KEYBOARD hanjp_keyboard_get_type()
-G_DECLARE_INTERFACE(HanjpKeyboard, hanjp_keyboard, HANJP, KEYBOARD, GObject)
+G_DECLARE_INTERFACE(HanjpKeyboard, hanjp_kb, HANJP, KB, GObject)
 
 struct _HanjpKeyboardInterface {
     GTypeInterface parent_iface;
@@ -14,16 +14,16 @@ struct _HanjpKeyboardInterface {
     gunichar (*get_mapping) (HanjpKeyboard *self, gint tableid, gint ascii);
 };
 
-gunichar hanjp_keyboard_get_mapping(HanjpKeyboard *self, gint tableid, gint ascii);
+gunichar hanjp_kb_get_mapping(HanjpKeyboard *self, gint tableid, gint ascii);
 
 #define HANJP_TYPE_KEYBOARDDEFAULT hanjp_keyboarddefault_get_type()
-G_DECLARE_DERIVABLE_TYPE(HanjpKeyboardDefault, hanjp_keyboarddefault, HANJP, KEYBOARDDEFAULT, GObject)
+G_DECLARE_DERIVABLE_TYPE(HanjpKeyboardBuiltin, hanjp_kb_builtin, HANJP, KB_BUILTIN, GObject)
 
-struct _HanjpKeyboardDefaultClass {
+struct _HanjpKeyboardBuiltinClass {
     GObjectClass parent_class;
 };
 
-HanjpKeyboardDefault *hanjp_keyboarddefault_new();
+HanjpKeyboardBuiltin *hanjp_kb_builtin_new();
 
 G_END_DECLS
 

--- a/test/test_gobj_construct_dispose.cpp
+++ b/test/test_gobj_construct_dispose.cpp
@@ -32,26 +32,26 @@ TEST(GObjectConstructDisposeTest, AutomataDefaultConstructDispose) {
 
 TEST(GObjectConstructDisposeTest, KeyboardDefaultConstructDispose) {
 	// Given HanjpKeyboardDefault object
-	HanjpKeyboardDefault *kbDefault = NULL;
+	HanjpKeyboardBuiltin *kbBuiltin = NULL;
 	const char* strExpectObjType = "HanjpKeyboardDefault";
 	const char* strActualObjType = NULL;
 
 	// When constructed
-	kbDefault = hanjp_keyboarddefault_new();
+	kbBuiltin = hanjp_kb_builtin_new();
 
 	// Then, object pointer must not be null
-	ASSERT_NE(kbDefault, nullptr)
+	ASSERT_NE(kbBuiltin, nullptr)
 		<< "HanjpKeyboardDefault construct failed";
 
 	// Then, object type name must be same as the class name
-	strActualObjType = G_OBJECT_TYPE_NAME(kbDefault);
+	strActualObjType = G_OBJECT_TYPE_NAME(kbBuiltin);
 	ASSERT_STREQ(strActualObjType, strExpectObjType);
 
 	// When destructed
-	g_object_unref(kbDefault);
+	g_object_unref(kbBuiltin);
 
 	// Then, type check must be false
-	ASSERT_FALSE(G_TYPE_CHECK_INSTANCE(kbDefault))
+	ASSERT_FALSE(G_TYPE_CHECK_INSTANCE(kbBuiltin))
 		<< "HanjpKeyboardDefault destruct failed";
 }
 

--- a/test/test_gobj_construct_dispose.cpp
+++ b/test/test_gobj_construct_dispose.cpp
@@ -6,34 +6,34 @@
 
 TEST(GObjectConstructDisposeTest, AutomataDefaultConstructDispose) {
 	// Given HanjpAutomataDefault object
-	HanjpAutomataDefault *amDefault = NULL;
-	const char* strExpectObjType = "HanjpAutomataDefault";
+	HanjpAutomataBuiltin *amBuiltin = NULL;
+	const char* strExpectObjType = "HanjpAutomataBuiltin";
 	const char* strActualObjType = NULL;
 
 	// When constructed
-	amDefault = hanjp_amdefault_new();
+	amBuiltin = hanjp_am_builtin_new();
 
 	// Then, object pointer must not be null
-	ASSERT_NE(amDefault, nullptr)
-		<< "HanjpAutomataDefault construct failed";
+	ASSERT_NE(amBuiltin, nullptr)
+		<< "HanjpAutomataBuiltin construct failed";
 	
 	// Then, object type name must be same as the class name
-	strActualObjType = G_OBJECT_TYPE_NAME(amDefault);
+	strActualObjType = G_OBJECT_TYPE_NAME(amBuiltin);
 	ASSERT_STREQ(strActualObjType, strExpectObjType);
 
 	// When destructed
-	g_object_unref(amDefault);
+	g_object_unref(amBuiltin);
 
 	// Then, type check must be false
-	ASSERT_FALSE(G_TYPE_CHECK_INSTANCE(amDefault))
-		<< "HanjpAutomataDefault destruct failed";
+	ASSERT_FALSE(G_TYPE_CHECK_INSTANCE(amBuiltin))
+		<< "HanjpAutomataBuiltin destruct failed";
 }
 
 
 TEST(GObjectConstructDisposeTest, KeyboardDefaultConstructDispose) {
 	// Given HanjpKeyboardDefault object
 	HanjpKeyboardBuiltin *kbBuiltin = NULL;
-	const char* strExpectObjType = "HanjpKeyboardDefault";
+	const char* strExpectObjType = "HanjpKeyboardBuiltin";
 	const char* strActualObjType = NULL;
 
 	// When constructed
@@ -41,7 +41,7 @@ TEST(GObjectConstructDisposeTest, KeyboardDefaultConstructDispose) {
 
 	// Then, object pointer must not be null
 	ASSERT_NE(kbBuiltin, nullptr)
-		<< "HanjpKeyboardDefault construct failed";
+		<< "HanjpKeyboardBuiltin construct failed";
 
 	// Then, object type name must be same as the class name
 	strActualObjType = G_OBJECT_TYPE_NAME(kbBuiltin);
@@ -52,7 +52,7 @@ TEST(GObjectConstructDisposeTest, KeyboardDefaultConstructDispose) {
 
 	// Then, type check must be false
 	ASSERT_FALSE(G_TYPE_CHECK_INSTANCE(kbBuiltin))
-		<< "HanjpKeyboardDefault destruct failed";
+		<< "HanjpKeyboardBuiltin destruct failed";
 }
 
 


### PR DESCRIPTION
This patch is refactoring for automata and keyboard.
It changes its own methods to short because previous names were too long.
It changes bellow files:
1) hanjpautomata.c, hanjpautomata.h:
HANJP_AUTOMATA -> HANJP_AM
hanjp_amderived -> hanjp_am_dervied
default -> builtin
hanjp_keyboard -> hanjp_kb related with '2'
2) hanjpkeyboard.c, hankeyboard.h
HANJP_KEYBOARD -> HANJP_KB
keyboardderived -> kb_derived
default -> builtin
3) hanjpinputcontext.h
Changes to new name(related with '1', '2')
4) test_gobj_contruct_dispose.c
Changes to new name(related with '1', '2')

